### PR TITLE
Start with fewer particles (10000 -> 1000)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,7 +20,7 @@ export class AppComponent {
     xRange: [-1, 1],
     yRange: [-1, 1],
     lifetime: 100,
-    particleCount: 10000,
+    particleCount: 1000,
     normalize: false,
     speed: 1,
     color1: [1, 1, 1, 1],


### PR DESCRIPTION
With poor performance computer (i.e. mine) starting with 10'000 particles just make the browser crash.
Therefore, reducing it to 1000 would allow users to use the simulation while having the ability to increase the count.